### PR TITLE
Remove pdf from display order for HTML export

### DIFF
--- a/jupyter_nbconvert/exporters/html.py
+++ b/jupyter_nbconvert/exporters/html.py
@@ -37,7 +37,15 @@ class HTMLExporter(TemplateExporter):
     def default_config(self):
         c = Config({
             'NbConvertBase': {
-                'display_data_priority' : ['application/javascript', 'text/html', 'text/markdown', 'application/pdf', 'image/svg+xml', 'text/latex', 'image/png', 'image/jpeg', 'text/plain']
+                'display_data_priority' : ['application/javascript',
+                                           'text/html',
+                                           'text/markdown',
+                                           'image/svg+xml',
+                                           'text/latex',
+                                           'image/png',
+                                           'image/jpeg',
+                                           'text/plain'
+                                          ]
                 },
             'CSSHTMLHeaderPreprocessor':{
                 'enabled':True


### PR DESCRIPTION
The HTML template has no means to display pdf, so this was hiding outputs with pdf representations.

The live notebook also appears to prefer png to svg, whereas the HTML export prefers svg. Should this be harmonised?

Closes jupyter/jupyter_notebook#31