### PR TITLE
Add jupyter_notebook to requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ install_requires = setuptools_args['install_requires'] = [
     'pygments',
     'traitlets',
     'jupyter_core',
+    'jupyter_notebook',  # For CSS files
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
We already added it to requirements.txt, it should be here as well.

Closes #4