### PR TITLE
Fix propagation of fragments across multiple slides/subslides.

### DIFF
--- a/jupyter_nbconvert/preprocessors/revealhelp.py
+++ b/jupyter_nbconvert/preprocessors/revealhelp.py
@@ -48,9 +48,15 @@ class RevealHelpPreprocessor(Preprocessor):
                 nb.cells[index].metadata.frag_number = index
                 i = 1
                 while i < len(nb.cells) - index:
-                    nb.cells[index + i].metadata.frag_helper = 'fragment_end'
-                    nb.cells[index + i].metadata.frag_number = index
-                    i += 1
+                    # We need to break the loop when a new slide or subslide is
+                    # found to avoid the propagation of the data-fragment-index
+                    # across multiple slides/subslides
+                    if nb.cells[index + i].metadata.slideshow.slide_type in ['slide', 'subslide']:
+                        break
+                    else:
+                        nb.cells[index + i].metadata.frag_helper = 'fragment_end'
+                        nb.cells[index + i].metadata.frag_number = index
+                        i += 1
             # Restart the slide_helper when the cell status is changed
             # to other types.
             if cell.metadata.slide_type in ['-', 'skip', 'notes', 'fragment']:


### PR DESCRIPTION
This fixes #9 

Essentially, we avoid labelling "-" cells with a previous data-fragment-index if we find a new slide/subslide. The fragments (and the group of fragments and "-" cells) only have sense inside a slide/subslide... it is an "intraslide" property and the data-fragment-index information has to be bounded to the slide/subslide containing the fragment/s (or fragments / "-" sequence).

I think the fix should be back-ported to the next 3.2 because right now you have unwanted fragments in your slides and that's very annoying.

Thanks!